### PR TITLE
Optimize HeroCard rendering for improved performance

### DIFF
--- a/src/components/hero-card/HeroCard.js
+++ b/src/components/hero-card/HeroCard.js
@@ -3,7 +3,7 @@ import "./hero-card.css"
 import { Link } from "react-router-dom"
 import FavoriteHeart from "../favorite-heart/FavoriteHeart"
 import Triangle from "../../images/triangle.png"
-const HeroCard = (props) => {
+const HeroCard = React.memo((props) => {
 	return (
 		<div className="hero-card-wrapper">
 			<Link to={`/hero/${props.data.id}`}>

--- a/src/views/HomeView.js
+++ b/src/views/HomeView.js
@@ -53,8 +53,8 @@ const Home = () => {
 				<InputSearch handleInputSearch={handleInputSearch} />
 				<TotalResultsSearch totalAmount={data.count} />
 				<div className="flex flex-wrap">
-					{data?.results?.map((hero, index) => (
-						<HeroCard data={hero} key={index} />
+					{data?.results?.map((hero) => (
+						<HeroCard data={hero} key={hero.id} />
 					))}
 				</div>
 			</div>


### PR DESCRIPTION
This commit introduces two key optimizations to the display of hero cards on the home page:

1.  **Use `hero.id` as key for `HeroCard`**: In `src/views/HomeView.js`, the `key` prop for mapped `HeroCard` components was changed from `index` to the stable and unique `hero.id`. This allows React to more efficiently track and update list items.

2.  **Memoize `HeroCard` component**: The `HeroCard` component (`src/components/hero-card/HeroCard.js`) is now wrapped with `React.memo`. This prevents the component from re-rendering if its props (`data`) have not changed. This is particularly beneficial in scenarios where parent components might re-render due to context changes (like `FavoritesContext`), ensuring that only necessary `HeroCard` instances are updated.

These changes aim to reduce unnecessary re-renders of hero cards, leading to a smoother user experience, especially when interacting with features like favoriting heroes.